### PR TITLE
Remove duplicate literal in ErrorCode

### DIFF
--- a/jwt_ninja/errors.py
+++ b/jwt_ninja/errors.py
@@ -58,7 +58,6 @@ ErrorCode = Literal[
     "invalid_token",
     "invalid_token_type",
     "invalid_user",
-    "invalid_token",
     "session_not_found",
     "session_expired",
 ]


### PR DESCRIPTION
## Summary
- Remove the duplicate `"invalid_token"` entry from the `ErrorCode` Literal union in `jwt_ninja/errors.py`.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest` (18 passed)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>