### PR TITLE
Bump dependency minimum versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,19 +5,19 @@ description = "A simple and fully-typed auth library for Django Ninja based on P
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "pydantic>=2.9.2",
-    "pydantic-settings>=2.5.2",
-    "pyjwt>=2.9.0",
-    "django-ninja>=1.3.0",
+    "pydantic>=2.11.0",
+    "pydantic-settings>=2.9.0",
+    "pyjwt>=2.10.0",
+    "django-ninja>=1.4.0",
 ]
 
 [tool.uv]
 dev-dependencies = [
-    "pytest-django>=4.9.0",
-    "pytest-freezer>=0.4.8",
+    "pytest-django>=4.11.0",
+    "pytest-freezer>=0.4.9",
     "pytest-mock>=3.14.0",
-    "pytest>=8.3.3",
-    "ruff>=0.6.9",
+    "pytest>=8.4.0",
+    "ruff>=0.12.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -98,19 +98,19 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django-ninja", specifier = ">=1.3.0" },
-    { name = "pydantic", specifier = ">=2.9.2" },
-    { name = "pydantic-settings", specifier = ">=2.5.2" },
-    { name = "pyjwt", specifier = ">=2.9.0" },
+    { name = "django-ninja", specifier = ">=1.4.0" },
+    { name = "pydantic", specifier = ">=2.11.0" },
+    { name = "pydantic-settings", specifier = ">=2.9.0" },
+    { name = "pyjwt", specifier = ">=2.10.0" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "pytest", specifier = ">=8.3.3" },
-    { name = "pytest-django", specifier = ">=4.9.0" },
-    { name = "pytest-freezer", specifier = ">=0.4.8" },
+    { name = "pytest", specifier = ">=8.4.0" },
+    { name = "pytest-django", specifier = ">=4.11.0" },
+    { name = "pytest-freezer", specifier = ">=0.4.9" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
-    { name = "ruff", specifier = ">=0.6.9" },
+    { name = "ruff", specifier = ">=0.12.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Raises production and dev dependency minimums in `pyproject.toml` to reflect versions already resolved in `uv.lock`, so fresh installs pick up reasonably current releases.
- Regenerates `uv.lock` via `uv lock`.
- Leaves `uuid6` untouched (separate PR is removing it).

### Production bumps
- `pydantic>=2.9.2` → `>=2.11.0`
- `pydantic-settings>=2.5.2` → `>=2.9.0`
- `pyjwt>=2.9.0` → `>=2.10.0`
- `django-ninja>=1.3.0` → `>=1.4.0`

### Dev bumps
- `pytest-django>=4.9.0` → `>=4.11.0`
- `pytest-freezer>=0.4.8` → `>=0.4.9`
- `pytest>=8.3.3` → `>=8.4.0`
- `ruff>=0.6.9` → `>=0.12.0`

## Test plan
- [x] `uv sync`
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest` (18 passed)
- [x] `uv build`