### PR TITLE
Fix get_client_ip return type and whitespace handling

### DIFF
--- a/jwt_ninja/request.py
+++ b/jwt_ninja/request.py
@@ -1,7 +1,7 @@
 from django.http import HttpRequest
 
 
-def get_client_ip(request: HttpRequest) -> str:
+def get_client_ip(request: HttpRequest) -> str | None:
     """
     Retrieve the client IP address from the given HttpRequest.
 
@@ -9,10 +9,9 @@ def get_client_ip(request: HttpRequest) -> str:
         request (HttpRequest): The HTTP request object.
 
     Returns:
-        str: The client IP address.
+        str | None: The client IP address, or None if it cannot be determined.
     """
     x_forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
     if x_forwarded_for:
-        return x_forwarded_for.split(",")[0]
-    else:
-        return request.META.get("REMOTE_ADDR")
+        return x_forwarded_for.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR")

--- a/jwt_ninja/tests/test_request.py
+++ b/jwt_ninja/tests/test_request.py
@@ -1,0 +1,34 @@
+from django.http import HttpRequest
+
+from ..request import get_client_ip
+
+
+def make_request(meta: dict[str, str] | None = None) -> HttpRequest:
+    request = HttpRequest()
+    request.META = meta or {}
+    return request
+
+
+def test_get_client_ip_single_x_forwarded_for():
+    request = make_request({"HTTP_X_FORWARDED_FOR": "1.1.1.1"})
+    assert get_client_ip(request) == "1.1.1.1"
+
+
+def test_get_client_ip_multiple_x_forwarded_for():
+    request = make_request({"HTTP_X_FORWARDED_FOR": "1.1.1.1,2.2.2.2"})
+    assert get_client_ip(request) == "1.1.1.1"
+
+
+def test_get_client_ip_x_forwarded_for_with_whitespace():
+    request = make_request({"HTTP_X_FORWARDED_FOR": "  1.1.1.1 , 2.2.2.2"})
+    assert get_client_ip(request) == "1.1.1.1"
+
+
+def test_get_client_ip_falls_back_to_remote_addr():
+    request = make_request({"REMOTE_ADDR": "3.3.3.3"})
+    assert get_client_ip(request) == "3.3.3.3"
+
+
+def test_get_client_ip_returns_none_when_no_headers():
+    request = make_request()
+    assert get_client_ip(request) is None


### PR DESCRIPTION
## Summary
- Return type is now `str | None` — `REMOTE_ADDR` can be missing, which previously let `None` leak out of a function annotated as `str`.
- `.strip()` the first `X-Forwarded-For` segment so values like `"  1.1.1.1 , 2.2.2.2"` don't trip Django's `GenericIPAddressField` validators.
- Drop the redundant `else` since the `if` returns.
- Add `jwt_ninja/tests/test_request.py` covering single/multi/whitespace XFF, `REMOTE_ADDR` fallback, and the no-headers `None` case.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest` — 23 passed (5 new)

Generated with Claude Code