### PR TITLE
Remove stale src/ leftover from versioning migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ wheels/
 # Virtual environments
 .venv
 .idea
+
+# Stale versioning leftover
+src/


### PR DESCRIPTION
## Summary
- Deletes the untracked `src/` directory containing only `src/example/_version.py` with `version = "9.0.0"`. This file was left over from PRs #14-#19 which migrated from static versioning to `uv-dynamic-versioning` (reading versions from git tags). No build step reads this file anymore.
- Adds `src/` to `.gitignore` so any future stray `src/` from tooling does not reappear in `git status`.

## Test plan
- [x] `uv sync --frozen`
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest` (18 passed)
- [x] `git status` shows only the `.gitignore` modification