### PR TITLE
Modernize typing: typing.Type → type, add missing return annotations

### DIFF
--- a/jwt_ninja/authenticators.py
+++ b/jwt_ninja/authenticators.py
@@ -1,10 +1,11 @@
 from typing import Any
 
 from django.contrib.auth import authenticate
+from django.contrib.auth.models import AbstractBaseUser
 from django.http import HttpRequest
 
 
-def django_user_authenticator(request: HttpRequest, payload: Any):
+def django_user_authenticator(request: HttpRequest, payload: Any) -> AbstractBaseUser | None:
     return authenticate(
         request=request,
         username=payload.username,

--- a/jwt_ninja/cryptography.py
+++ b/jwt_ninja/cryptography.py
@@ -1,5 +1,3 @@
-from typing import Type
-
 import jwt
 from pydantic import ValidationError
 
@@ -25,13 +23,13 @@ def generate_jwt(payload: JWTPayload) -> str:
     )
 
 
-def decode_jwt(token: str, payload_class: Type[JWTPayload]) -> JWTPayload:
+def decode_jwt(token: str, payload_class: type[JWTPayload]) -> JWTPayload:
     """
     Decodes a JSON Web Token (JWT) and returns the payload.
 
     Args:
         token (str): The encoded JWT as a string.
-        payload_class (Type[JWTPayload]): The class to deserialize the payload into.
+        payload_class (type[JWTPayload]): The class to deserialize the payload into.
 
     Returns:
         JWTPayload: The deserialized payload.

--- a/jwt_ninja/handlers.py
+++ b/jwt_ninja/handlers.py
@@ -3,7 +3,7 @@ from django.http import HttpRequest, JsonResponse
 from .errors import APIError
 
 
-def error_handler(request: HttpRequest, exc: APIError):
+def error_handler(request: HttpRequest, exc: APIError) -> JsonResponse:
     return JsonResponse(
         {"error_code": exc.error_code},
         status=exc.http_status_code,


### PR DESCRIPTION
## Summary
- Replace `typing.Type` with PEP 585 builtin `type` generic in `cryptography.py` (and docstring).
- Add `-> AbstractBaseUser | None` return annotation to `django_user_authenticator`.
- Add `-> JsonResponse` return annotation to `error_handler`.

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest` (18 passed)

Generated with Claude Code