### PR TITLE
Add tests for error_handler

### DIFF
--- a/jwt_ninja/tests/test_handlers.py
+++ b/jwt_ninja/tests/test_handlers.py
@@ -1,0 +1,26 @@
+import json
+
+import pytest
+from django.http import HttpRequest
+
+from ..errors import APIError
+from ..handlers import error_handler
+
+
+@pytest.mark.parametrize(
+    ("error_code", "http_status_code"),
+    [
+        ("invalid_credentials", 401),
+        ("invalid_token_type", 400),
+        ("session_expired", 401),
+    ],
+)
+def test_error_handler_returns_json_response(error_code, http_status_code):
+    request = HttpRequest()
+    exc = APIError(error_code, http_status_code)
+
+    response = error_handler(request, exc)
+
+    assert response.status_code == http_status_code
+    assert json.loads(response.content) == {"error_code": error_code}
+    assert response["Content-Type"] == "application/json"


### PR DESCRIPTION
## Summary
- Add `jwt_ninja/tests/test_handlers.py` covering `error_handler`.
- Parametrized test verifies body, HTTP status code, and Content-Type across `invalid_credentials` (401), `invalid_token_type` (400), and `session_expired` (401).

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest`

Generated with Claude Code