### PR TITLE
Add tests for django_user_authenticator

### DIFF
--- a/jwt_ninja/tests/test_authenticators.py
+++ b/jwt_ninja/tests/test_authenticators.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+from django.http import HttpRequest
+
+from ..authenticators import django_user_authenticator
+
+
+@pytest.mark.django_db
+def test_valid_credentials_returns_user(test_user):
+    payload = SimpleNamespace(username="dan", password="dan")
+    user = django_user_authenticator(HttpRequest(), payload)
+    assert user == test_user
+
+
+@pytest.mark.django_db
+def test_wrong_password_returns_none(test_user):
+    payload = SimpleNamespace(username="dan", password="wrong")
+    assert django_user_authenticator(HttpRequest(), payload) is None
+
+
+@pytest.mark.django_db
+def test_nonexistent_username_returns_none(test_user):
+    payload = SimpleNamespace(username="ghost", password="dan")
+    assert django_user_authenticator(HttpRequest(), payload) is None
+
+
+@pytest.mark.django_db
+def test_inactive_user_returns_none(test_user):
+    test_user.is_active = False
+    test_user.save()
+
+    payload = SimpleNamespace(username="dan", password="dan")
+    assert django_user_authenticator(HttpRequest(), payload) is None


### PR DESCRIPTION
## Summary
- Add `jwt_ninja/tests/test_authenticators.py` covering `django_user_authenticator`
- Tests: valid credentials return the user; wrong password, nonexistent username, and inactive user all return `None`

## Test plan
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest` (22 passed)

Generated with [Claude Code](https://claude.com/claude-code)