### PR TITLE
Define public API in jwt_ninja/__init__.py

### DIFF
--- a/jwt_ninja/__init__.py
+++ b/jwt_ninja/__init__.py
@@ -1,0 +1,24 @@
+from .cryptography import decode_jwt, generate_jwt
+from .errors import APIError
+from .types import JWTPayload
+
+__all__ = [
+    "APIError",
+    "AuthDetails",
+    "AuthedRequest",
+    "JWTAuth",
+    "JWTPayload",
+    "decode_jwt",
+    "generate_jwt",
+]
+
+
+def __getattr__(name: str):
+    # Lazy re-exports from .auth_classes. Imported on first access so that
+    # Django can load jwt_ninja as an app without triggering get_user_model()
+    # before the app registry is ready.
+    if name in {"AuthDetails", "AuthedRequest", "JWTAuth"}:
+        from . import auth_classes
+
+        return getattr(auth_classes, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

- Adds a curated `__all__` to `jwt_ninja/__init__.py` re-exporting the public surface: `APIError`, `AuthDetails`, `AuthedRequest`, `JWTAuth`, `JWTPayload`, `decode_jwt`, `generate_jwt`.
- Users can now write `from jwt_ninja import JWTAuth` instead of deep submodule paths like `from jwt_ninja.auth_classes import JWTAuth`.
- `auth_classes` re-exports (`AuthDetails`, `AuthedRequest`, `JWTAuth`) are loaded lazily via module-level `__getattr__`, because `jwt_ninja` is in `INSTALLED_APPS` and `auth_classes.py` calls `get_user_model()` at module level — eager import would raise `AppRegistryNotReady` during `django.setup()`.

## Not re-exported (intentional)

- `router` and `error_handler` from `.api` — would instantiate `JWTAuth()` during route-decorator evaluation at import time.
- `Session` from `.models` — would break before `django.setup()` completes.

Users who want these should keep importing from their submodule paths.

## Import-before-setup caveat

The optional second smoke test (`import jwt_ninja` with no `DJANGO_SETTINGS_MODULE`) fails because `cryptography.py` / `settings.py` / `types.py` already access Django settings or `ninja` at module-load time. This is a pre-existing constraint of the codebase (not introduced by this PR) and fixing it would require touching files outside this unit's scope. The primary smoke test (with `django.setup()`) passes cleanly.

## Test plan

- [x] `uv sync --frozen`
- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest` (18 passed)
- [x] `uv build` (wheel + sdist built cleanly)
- [x] `DJANGO_SETTINGS_MODULE=jwt_ninja.tests.django_settings uv run python -c "import django; django.setup(); import jwt_ninja; print(jwt_ninja.__all__); print(jwt_ninja.JWTAuth)"` prints the list and the class with no errors.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>