### PR TITLE
Fix pyrefly-surfaced bugs in api.py and models.py

### DIFF
--- a/jwt_ninja/api.py
+++ b/jwt_ninja/api.py
@@ -128,7 +128,7 @@ def new_refresh_token(request: HttpRequest, payload: RefreshTokenSchema) -> Any:
     auth=JWTAuth(),
 )
 def list_active_sessions(request: AuthedRequest):
-    return request.auth.user.jwt_sessions.filter(expired_at__isnull=True)
+    return Session.objects.filter(user=request.auth.user, expired_at__isnull=True)
 
 
 @router.post(

--- a/jwt_ninja/models.py
+++ b/jwt_ninja/models.py
@@ -89,7 +89,7 @@ class Session(models.Model):
         ).delete()
 
     @classmethod
-    def create_session(cls, user, ip_address: str) -> "Session":
+    def create_session(cls, user, ip_address: str | None) -> "Session":
         """
         Create a new session from a request.
         """


### PR DESCRIPTION
## Summary

Two issues surfaced by pyrefly (#32) after the Django ORM experimental support was enabled:

- **`jwt_ninja/models.py`** — `Session.create_session` annotated `ip_address: str`, but its only caller (`api.py:51`) passes `get_client_ip(request)` which returns `str | None` after #25. The underlying `GenericIPAddressField` is `null=True`, so `None` was already accepted at runtime — the annotation was just wrong. Loosened to `str | None`.

- **`jwt_ninja/api.py:list_active_sessions`** — rewrote `request.auth.user.jwt_sessions.filter(...)` as `Session.objects.filter(user=request.auth.user, ...)`. Functionally identical; forward lookups are typed properly by pyrefly while reverse-relationship accessors are a [known pyrefly limitation](https://pyrefly.org/en/docs/django/). Matches the idiom already used in `logout_all` elsewhere in the same file.

After these two changes `pyrefly check` on the source modules reports **0 errors**, which would let #32 flip its CI job to a hard blocker.

## Test plan

- [x] `uv run ruff format --check .`
- [x] `uv run ruff check .`
- [x] `uv run pytest` (54 passed)
- [x] `uv run --with pyrefly --with django-stubs pyrefly check jwt_ninja/api.py jwt_ninja/models.py` → 0 errors