### PR TITLE
Warn when JWT signing key is shorter than RFC 7518 requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,13 +180,35 @@ JWT_PAYLOAD_CLASS = "jwt_ninja.types.JWTPayload"
 
 | Setting                              | Type  | Description                                                                                   |
 | ------------------------------------ | ----- | --------------------------------------------------------------------------------------------- |
-| `JWT_SECRET_KEY`                     | `str` | Signing key. Defaults to Django's `SECRET_KEY`.                                               |
+| `JWT_SECRET_KEY`                     | `str` | Signing key. Defaults to Django's `SECRET_KEY`. See [Signing key length](#signing-key-length). |
 | `JWT_ALGORITHM`                      | `str` | PyJWT algorithm. Symmetric (`HS*`) or asymmetric (`RS*`, `ES*`, …).                          |
 | `JWT_ACCESS_TOKEN_EXPIRE_SECONDS`    | `int` | Lifetime of the short-lived access token.                                                    |
 | `JWT_REFRESH_TOKEN_EXPIRE_SECONDS`   | `int` | Lifetime of the refresh token.                                                               |
 | `JWT_SESSION_EXPIRE_SECONDS`         | `int` | Max age of the DB `Session` row before it's considered expired by housekeeping.              |
 | `JWT_USER_LOGIN_AUTHENTICATOR`       | `str` | Dotted path to a callable `(request, payload) -> User \| None` used by `/auth/login/`.       |
 | `JWT_PAYLOAD_CLASS`                  | `str` | Dotted path to a `JWTPayload` subclass if you need custom claims.                            |
+
+### Signing key length
+
+For HMAC algorithms (the `HS*` family, including the default `HS256`), [RFC 7518 §3.2](https://www.rfc-editor.org/rfc/rfc7518#section-3.2) requires the signing key to be at least the size of the hash output:
+
+| Algorithm | Minimum key size |
+| --------- | ---------------- |
+| `HS256`   | 32 bytes         |
+| `HS384`   | 48 bytes         |
+| `HS512`   | 64 bytes         |
+
+Shorter keys are padded internally and give attackers a smaller space to search — an attacker who recovers the key can forge arbitrary tokens for any user.
+
+**JWT Ninja emits `jwt_ninja.settings.InsecureJWTKeyWarning` at startup if your configured key is too short**, so you'll see it in your app logs as soon as the settings load. PyJWT also emits its own `InsecureKeyLengthWarning` at encode/decode time.
+
+Django's `get_random_secret_key()` already produces 50-character keys, so fresh projects are fine. Short keys typically show up in older projects or in manually-set `JWT_SECRET_KEY` values. To generate a suitable key:
+
+```bash
+python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"
+```
+
+Rotating the key invalidates all existing JWT Ninja sessions (existing tokens fail signature verification), so users will need to re-authenticate after deploying the change.
 
 ## Custom Claims
 

--- a/jwt_ninja/settings.py
+++ b/jwt_ninja/settings.py
@@ -1,3 +1,5 @@
+import warnings
+
 from django.conf import settings
 from django.core.signals import setting_changed
 from django.utils.module_loading import import_string
@@ -5,6 +7,41 @@ from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from .types import JWTPayload
+
+
+class InsecureJWTKeyWarning(UserWarning):
+    """
+    Emitted when the configured JWT signing key is shorter than the HMAC
+    algorithm's recommended minimum per RFC 7518 §3.2. Short keys weaken
+    HMAC security; PyJWT also emits its own InsecureKeyLengthWarning at
+    encode/decode time.
+    """
+
+
+# RFC 7518 §3.2: HMAC keys should be at least the hash output size.
+_HMAC_MIN_KEY_BYTES = {
+    "HS256": 32,
+    "HS384": 48,
+    "HS512": 64,
+}
+
+
+def _warn_if_key_too_short(secret_key: str, algorithm: str) -> None:
+    minimum = _HMAC_MIN_KEY_BYTES.get(algorithm)
+    if minimum is None:
+        return
+    key_bytes = len(secret_key.encode("utf-8"))
+    if key_bytes >= minimum:
+        return
+    warnings.warn(
+        f"JWT signing key is {key_bytes} bytes, but {algorithm} requires at least "
+        f"{minimum} bytes per RFC 7518 §3.2. Set JWT_SECRET_KEY (or rotate Django's "
+        f"SECRET_KEY) to a random value with at least {minimum} bytes of entropy. "
+        f"Short HMAC keys reduce the security margin of your tokens — an attacker "
+        f"who recovers the key can forge arbitrary tokens.",
+        InsecureJWTKeyWarning,
+        stacklevel=3,
+    )
 
 
 class JWTSettings(BaseSettings):
@@ -34,6 +71,7 @@ class JWTSettings(BaseSettings):
                 django_overrides[field_name] = getattr(settings, django_key)
         super().__init__(**django_overrides)
         self._JWT_PAYLOAD_CLASS = import_string(self.JWT_PAYLOAD_CLASS)
+        _warn_if_key_too_short(self.SECRET_KEY, self.ALGORITHM)
 
     @property
     def payload_class(self) -> type[JWTPayload]:

--- a/jwt_ninja/tests/django_settings.py
+++ b/jwt_ninja/tests/django_settings.py
@@ -1,4 +1,4 @@
-SECRET_KEY = "fake-key"
+SECRET_KEY = "fake-key-long-enough-for-hs256-testing-32b+"  # 44 bytes, avoids InsecureJWTKeyWarning
 INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",

--- a/jwt_ninja/tests/test_settings.py
+++ b/jwt_ninja/tests/test_settings.py
@@ -1,3 +1,5 @@
+import warnings
+
 import pytest
 from django.core.signals import setting_changed
 from django.test import override_settings
@@ -5,7 +7,7 @@ from django.test import override_settings
 import jwt_ninja.settings as jwt_ninja_settings
 
 from ..cryptography import decode_jwt, generate_jwt
-from ..settings import jwt_settings
+from ..settings import InsecureJWTKeyWarning, JWTSettings, jwt_settings
 from ..types import JWTPayload
 
 
@@ -158,3 +160,69 @@ def test_str_user_id_subclass_rejects_int_input():
             exp=9999999999,
             session_id="s",
         )
+
+
+def test_short_hmac_key_emits_insecure_warning():
+    """
+    When the configured JWT signing key is shorter than RFC 7518 §3.2
+    requires for the selected HMAC algorithm, JWTSettings emits an
+    InsecureJWTKeyWarning at instantiation time so the user learns about
+    it at startup rather than only at first encode/decode.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with override_settings(JWT_SECRET_KEY="too-short", JWT_ALGORITHM="HS256"):
+            pass  # override_settings fires reload_jwt_settings → JWTSettings()
+
+    matches = [w for w in caught if issubclass(w.category, InsecureJWTKeyWarning)]
+    assert matches, f"expected InsecureJWTKeyWarning, got: {[w.category.__name__ for w in caught]}"
+    message = str(matches[0].message)
+    assert "HS256" in message
+    assert "32 bytes" in message
+    assert "JWT_SECRET_KEY" in message
+
+
+def test_sufficiently_long_key_does_not_warn():
+    """
+    A key at or above the algorithm's minimum does not emit the warning.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with override_settings(JWT_SECRET_KEY="x" * 32, JWT_ALGORITHM="HS256"):
+            pass
+
+    assert not [w for w in caught if issubclass(w.category, InsecureJWTKeyWarning)]
+
+
+def test_non_hmac_algorithm_does_not_warn_on_short_key():
+    """
+    The RFC 7518 §3.2 minimum only applies to HMAC (HS*) algorithms.
+    A short key paired with a non-HMAC algorithm (e.g., RS256) does not
+    trigger the check — asymmetric key-length rules are different and
+    jwt_ninja doesn't try to validate them here.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        # We're not actually encoding — just testing that the check
+        # is scoped to HMAC algorithms.
+        JWTSettings.__init__  # silence unused-import complaints if any
+        with override_settings(JWT_SECRET_KEY="short", JWT_ALGORITHM="RS256"):
+            pass
+
+    assert not [w for w in caught if issubclass(w.category, InsecureJWTKeyWarning)]
+
+
+def test_hs512_has_higher_minimum_than_hs256():
+    """
+    HS512 requires 64 bytes; a 32-byte key that's fine for HS256 should
+    still warn under HS512. Confirms the per-algorithm minimums table.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with override_settings(JWT_SECRET_KEY="x" * 32, JWT_ALGORITHM="HS512"):
+            pass
+
+    matches = [w for w in caught if issubclass(w.category, InsecureJWTKeyWarning)]
+    assert matches
+    assert "HS512" in str(matches[0].message)
+    assert "64 bytes" in str(matches[0].message)


### PR DESCRIPTION
## Summary

Emits a new \`jwt_ninja.settings.InsecureJWTKeyWarning\` at startup when the configured signing key is shorter than [RFC 7518 §3.2](https://www.rfc-editor.org/rfc/rfc7518#section-3.2) requires for the selected HMAC algorithm:

| Algorithm | Minimum key size |
| --------- | ---------------- |
| \`HS256\`   | 32 bytes         |
| \`HS384\`   | 48 bytes         |
| \`HS512\`   | 64 bytes         |

Background: a user reported seeing PyJWT's \`InsecureKeyLengthWarning\` in their app logs. PyJWT raises it on every encode/decode, but that means the issue only surfaces once real traffic flows — not when the settings first load. This PR brings the warning forward to \`JWTSettings.__init__\`, so it shows up in startup logs with a clear, actionable message:

> JWT signing key is 28 bytes, but HS256 requires at least 32 bytes per RFC 7518 §3.2. Set JWT_SECRET_KEY (or rotate Django's SECRET_KEY) to a random value with at least 32 bytes of entropy. Short HMAC keys reduce the security margin of your tokens — an attacker who recovers the key can forge arbitrary tokens.

Non-HMAC algorithms (\`RS*\`, \`ES*\`, etc.) are not checked — asymmetric key-length rules are different and out of scope for this warning.

## Changes

- **\`jwt_ninja/settings.py\`** — new \`InsecureJWTKeyWarning\` class (subclass of \`UserWarning\` so it can be filtered independently); \`_warn_if_key_too_short\` helper; \`JWTSettings.__init__\` calls it after \`super().__init__()\`.
- **\`jwt_ninja/tests/django_settings.py\`** — bumped \`SECRET_KEY\` from \`\"fake-key\"\` (8 bytes) to a 44-byte value so the test suite doesn't emit the new warning on every reload.
- **README** — new \"Signing key length\" subsection with the algorithms-minima table, key-generation recipe, and a note that rotating the key invalidates existing sessions.

## Tests (4 new)

- \`test_short_hmac_key_emits_insecure_warning\` — HS256 with a 9-byte key triggers the warning; message contains \"HS256\", \"32 bytes\", \"JWT_SECRET_KEY\".
- \`test_sufficiently_long_key_does_not_warn\` — 32-byte key with HS256 is silent.
- \`test_non_hmac_algorithm_does_not_warn_on_short_key\` — short key with RS256 is silent (scoped check).
- \`test_hs512_has_higher_minimum_than_hs256\` — 32 bytes is fine for HS256 but triggers the warning under HS512 (64 byte minimum).

## Test plan

- [x] \`uv run ruff format --check .\`
- [x] \`uv run ruff check .\`
- [x] \`uv run pytest\` — 63 passed (was 59)
- [x] \`uv run pyrefly check jwt_ninja/settings.py\` — 0 errors